### PR TITLE
Feat debounce queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,3 +208,36 @@ export default {
   ]
 }
 ```
+
+## Debouncing queries
+You can enable  [debounce](https://davidwalsh.name/javascript-debounce-function) for queries at a global level, or mixin level. The query will be executed once immediately the first time, afterwards it won't be executed again if it's called before its `debounceTimeout` is expired. This is useful if you need to fire a query according to a text input change for example.
+By default, debouncing is disabled for all queries.
+
+### use at global level
+
+```js
+import ApiPlugin from 'vue-api-platform/plugin'
+
+Vue.use(ApiPlugin, {
+  debounce: Boolean, // default to false
+  debounceTimeout: Number // defaults to 500ms
+  // other options...
+})
+```
+
+### use at mixin level
+
+```js
+import ApiMixin from 'vue-api-platform/mixin'
+export default {
+  mixin: [
+    ApiMixin('myEntity', {
+      options: {
+        debounce: Boolean, // default to false
+        debounceTimeout: Number // defaults to 500ms
+      }
+      // other options...
+    })
+  ]
+}
+```

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -2,7 +2,7 @@ import uniq from 'lodash.uniq'
 import debounce from 'lodash/debounce'
 import fetchIntercept from '@neorel/fetch-intercept'
 
-const DEFAULT_DEBOUNCE_TIMEOUT = 500;
+const DEFAULT_DEBOUNCE_TIMEOUT = 200;
 
 const datas = {
   bindings: [],
@@ -379,7 +379,7 @@ const cacheDatas = function (data) {
 }
 
 export default {
-  install(Vue, {debounce = true, debounceTimeout = DEFAULT_DEBOUNCE_TIMEOUT, mercure = {}}) {
+  install(Vue, {debounce = false, debounceTimeout = DEFAULT_DEBOUNCE_TIMEOUT, mercure = {}}) {
     datas.mercure = {
       listeners: [],
       topics: [],

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -287,7 +287,6 @@ class ApiBinding {
   }
   
   _update(targets, array=false, options=this.options) {
-    console.log('debounced update')
     this.targets = targets
     this.array = array
     this.options = options
@@ -440,6 +439,12 @@ export default {
               }
               if (apiOptions[key].hasOwnProperty('pages') && apiOptions[key].pages instanceof Function) {
                 options.pages = apiOptions[key].pages.bind(this)()
+              }
+              if (apiOptions[key].hasOwnProperty('debounce')) {
+                options.debounce = !!apiOptions[key].debounce;
+              }
+              if (apiOptions[key].hasOwnProperty('debounceTimeout') && typeof apiOptions[key].debounceTimeout === 'number') {
+                options.debounceTimeout = apiOptions[key].debounceTimeout;
               }
             }
             if (func) {

--- a/plugin/index.js
+++ b/plugin/index.js
@@ -1,5 +1,8 @@
 import uniq from 'lodash.uniq'
+import debounce from 'lodash/debounce'
 import fetchIntercept from '@neorel/fetch-intercept'
+
+const DEFAULT_DEBOUNCE_TIMEOUT = 500;
 
 const datas = {
   bindings: [],
@@ -255,6 +258,9 @@ class ApiBinding {
     this.isLoading = false
     this.vm.$data.$apiBindings = [...this.vm.$data.$apiBindings, this]
     this.options = options
+    this.update = this.options && this.options.debounce 
+      ? debounce(this._update.bind(this), this.options.debounceTimeout, { leading: true })
+      : this._update;
   }
 
   startBinding() {
@@ -279,8 +285,9 @@ class ApiBinding {
     binding.bind()
     return binding
   }
-
-  update(targets, array=false, options=this.options) {
+  
+  _update(targets, array=false, options=this.options) {
+    console.log('debounced update')
     this.targets = targets
     this.array = array
     this.options = options
@@ -373,12 +380,12 @@ const cacheDatas = function (data) {
 }
 
 export default {
-  install(Vue, {mercure = {}}) {
+  install(Vue, {debounce = true, debounceTimeout = DEFAULT_DEBOUNCE_TIMEOUT, mercure = {}}) {
     datas.mercure = {
       listeners: [],
       topics: [],
       withCredentials: true,
-      ...mercure
+      ...mercure,
     }
     if (window) {
       window.ApiDatas = datas
@@ -464,6 +471,7 @@ export default {
     })
 
     Vue.prototype.$bindApi = function (key, target, options={}) {
+      const defaultOptions = { debounce, debounceTimeout }
       const dataUrls = generateUrls(target)
       if (!dataUrls || dataUrls.length === 0) {
         this[key] = Array.isArray(target) ? [] : null
@@ -474,7 +482,7 @@ export default {
       if (binding) {
         binding.update(dataUrls, Array.isArray(target), options)
       } else {
-        ApiBinding.create(dataUrls, this, key, Array.isArray(target), options)
+        ApiBinding.create(dataUrls, this, key, Array.isArray(target), Object.assign(defaultOptions, options))
       }
 
     }


### PR DESCRIPTION
Cette PR allows to debounce queries.
This functionality is not enabled by default, but can be turned off, on the global and mixin level. It is also possible to change the debounce timeout :

```
// Global level
Vue.use(ApiPlatformPlugin, {
  debounce: true,
  debounceTimeout: Number (default to 200ms),
  // ...other options
})

// Mixin level
{
  mixins: [
    ApiMixin('myEntity', {
        options: { debounce: true }
        //...other options
    }
  ]
}
```